### PR TITLE
Use main conda repo instead of conda-forge

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -44,7 +44,8 @@ conda create -y --prefix ./env \
     numpy \
     tensorflow \
     jupyterlab \
-    pytest 
+    pytest \
+    keras
 
 echo << EOM
 Anaconda virtualenv installed in ./env.

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -42,10 +42,9 @@ rm -rf ./env
 conda create -y --prefix ./env \
     python=${PYTHON_VERSION} \
     numpy \
-    tensorflow\
+    tensorflow \
     jupyterlab \
-    pytest \
-    -c conda-forge
+    pytest 
 
 echo << EOM
 Anaconda virtualenv installed in ./env.


### PR DESCRIPTION
Anaconda has moved their TensorFlow package to the main repo. If you install from conda-forge, you get TensorFlow 1.10. This PR switches the environment script to use the main repo, which results in TF 1.12 getting installed under ./env.