### PR TITLE
Handle duplicate items in collections

### DIFF
--- a/graph_def_editor/node.py
+++ b/graph_def_editor/node.py
@@ -647,13 +647,11 @@ class Node(object):
     """
     Add the node to the indicated collection.
     """
-    if collection_name in self._collection_names:
-      raise ValueError("Node '{}' already in collection '{}'".format(
-        self.name, collection_name))
-    self._collection_names.add(collection_name)
-    # Invalidate any information the parent graph may have cached about
-    # collections.
-    self._graph.increment_version_counter()
+    if collection_name not in self._collection_names:
+      self._collection_names.add(collection_name)
+      # Invalidate any information the parent graph may have cached about
+      # collections.
+      self._graph.increment_version_counter()
 
 
 ################################################################################

--- a/graph_def_editor/tensor.py
+++ b/graph_def_editor/tensor.py
@@ -124,10 +124,8 @@ class Tensor(object):
     """
     Add the tensor to the indicated collection.
     """
-    if collection_name in self._collection_names:
-      raise ValueError("Tensor '{}' already in collection '{}'".format(
-        self.name, collection_name))
-    self._collection_names.add(collection_name)
-    # Invalidate any information the parent graph may have cached about
-    # collections.
-    self.node._graph.increment_version_counter()
+    if collection_name not in self._collection_names:
+      self._collection_names.add(collection_name)
+      # Invalidate any information the parent graph may have cached about
+      # collections.
+      self.node._graph.increment_version_counter()

--- a/graph_def_editor/variable.py
+++ b/graph_def_editor/variable.py
@@ -230,13 +230,11 @@ class Variable(object):
     """
     Add the variable to the indicated collection.
     """
-    if collection_name in self._collection_names:
-      raise ValueError("Variable '{}' already in collection '{}'".format(
-        self._variable_name, collection_name))
-    self._collection_names.add(collection_name)
-    # Invalidate any information the parent graph may have cached about
-    # collections.
-    self._graph.increment_version_counter()
+    if collection_name not in self._collection_names:
+      self._collection_names.add(collection_name)
+      # Invalidate any information the parent graph may have cached about
+      # collections.
+      self._graph.increment_version_counter()
 
 
 


### PR DESCRIPTION
This change removes the error raised if an item has already been added to a collection, and does nothing.  This is required because TensorFlow does not treat collections as a set and allows duplicate entries.

Fixes #22 