### PR TITLE
Example of fold_batch_norms_up() rewrite

### DIFF
--- a/examples/mobilenet_example.py
+++ b/examples/mobilenet_example.py
@@ -1,0 +1,234 @@
+# Coypright 2018 IBM. All Rights Reserved.
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Example of using the GraphDef editor and the Graph Transform Tool to prep a
+copy of MobileNetV2 for inference.
+
+To run this example from the root of the project, type:
+   PYTHONPATH=$PWD env/bin/python examples/mobilenet_example.py
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import tensorflow as tf
+import graph_def_editor as gde
+import numpy as np
+import PIL
+import shutil
+import tarfile
+import textwrap
+import keras
+import urllib.request
+
+from tensorflow.tools import graph_transforms
+
+FLAGS = tf.flags.FLAGS
+
+
+def _indent(s):
+  return textwrap.indent(str(s), "    ")
+
+
+_TMP_DIR = "/tmp/mobilenet_example"
+_SAVED_MODEL_DIR = _TMP_DIR + "/original_model"
+_FROZEN_GRAPH_FILE = "{}/frozen_graph.pbtext".format(_TMP_DIR)
+_TF_REWRITES_GRAPH_FILE = "{}/after_tf_rewrites_graph.pbtext".format(_TMP_DIR)
+_GDE_REWRITES_GRAPH_FILE = "{}/after_gde_rewrites_graph.pbtext".format(_TMP_DIR)
+_AFTER_MODEL_FILES = [
+  _FROZEN_GRAPH_FILE, _TF_REWRITES_GRAPH_FILE, _GDE_REWRITES_GRAPH_FILE
+]
+_USE_KERAS = False
+
+# Panda pic from Wikimedia; also used in
+# https://github.com/tensorflow/models/blob/master/research/slim/nets ...
+#   ... /mobilenet/mobilenet_example.ipynb
+_PANDA_PIC_URL = ("https://upload.wikimedia.org/wikipedia/commons/f/fe/"
+                  "Giant_Panda_in_Beijing_Zoo_1.JPG")
+_PANDA_PIC_FILE = _TMP_DIR + "/panda.jpg"
+
+def _clear_dir(path: str):
+  if os.path.isdir(path):
+    shutil.rmtree(path)
+  os.mkdir(path)
+
+
+def _protobuf_to_file(pb, path, human_readable_name):
+  with open(path, "w") as f:
+    f.write(str(pb))
+  print("{} written to {}".format(human_readable_name, path))
+
+
+def get_keras_frozen_graph():
+  """
+  Generate a frozen graph for the Keras MobileNet_v2 model.
+
+  This should work, but does NOT work as of TensorFlow 1.12. The
+  save_keras_model() function in TensorFlow creates a graph that the
+  convert_variables_to_constants() function can't consume correctly.
+
+  Returns GraphDef, input node name, output node name
+  """
+  # Start with the pretrained MobileNetV2 model from keras.applications,
+  # wrapped as a tf.keras model.
+  mobilenet = tf.keras.applications.MobileNetV2()
+  # Because we're using a tf.keras model instead of a keras model,
+  # the backing TensorFlow session (keras.backend.get_session()) will have a
+  # ginormous graph with many unused nodes. The only supported API to filter
+  # down that graph is to write the model out as a SavedModel "file". So
+  # that's what we do here.
+  # Note that save_keras_model() doesn't write the model to the path you told
+  # it to use. It writes the model to a timestamped subdirectory and returns
+  # the path of the subdirectory as a bytes object (NOT a string).
+  actual_saved_model_directory_bytes = \
+    tf.contrib.saved_model.save_keras_model(mobilenet, _SAVED_MODEL_DIR,
+                                            as_text=True)
+  print("Initial SavedModel file is at {}".format(tf.compat.as_str(
+    actual_saved_model_directory_bytes)))
+  # Now we need to freeze the graph, i.e. convert all variables to Const nodes.
+  # The only supported way to do this with a Keras model is to write out a
+  # SavedModel file, read the SavedModel file back into a fresh session,
+  # and invoke the appropriate rewrite from tf.graph_util.
+  with tf.Session() as sess:
+    # save_keras_model() uses the "serve" tag for inference graphs, and the
+    # names of the output nodes are the same as those returned by Model.outputs
+    tf.saved_model.load(sess, tags=["serve"],
+                        export_dir=actual_saved_model_directory_bytes)
+    frozen_graph_def = tf.graph_util.convert_variables_to_constants(
+      sess, sess.graph.as_graph_def(),
+      output_node_names=[n.op.name for n in mobilenet.outputs])
+  return (frozen_graph_def, mobilenet.inputs[0].op.name,
+          mobilenet.outputs[0].op.name)
+
+
+def get_slim_frozen_graph():
+  """
+  Obtains a MobileNet_v2 model from the TensorFlow model zoo
+
+  Returns GraphDef, input op name, output op name
+  """
+  # Download a checkpoint if we don't have a cached one in our temp dir.
+  # See
+  # https://github.com/tensorflow/models/tree/master/research/slim/nets ...
+  #             ... /mobilenet
+  # for a full list of available checkpoints.
+  _CHECKPOINT_NAME = "mobilenet_v2_1.0_224"
+  _CHECKPOINT_URL = "https://storage.googleapis.com/mobilenet_v2/checkpoints" \
+                    "/{}.tgz".format(_CHECKPOINT_NAME)
+  _CHECKPOINT_TGZ = "{}/{}.tgz".format(_TMP_DIR, _CHECKPOINT_NAME)
+  _FROZEN_GRAPH_MEMBER = "./{}_frozen.pb".format(_CHECKPOINT_NAME)
+
+  if not os.path.exists(_CHECKPOINT_TGZ):
+    urllib.request.urlretrieve(_CHECKPOINT_URL, _CHECKPOINT_TGZ)
+  with tarfile.open(_CHECKPOINT_TGZ) as t:
+    frozen_graph_bytes = t.extractfile(_FROZEN_GRAPH_MEMBER).read()
+    return (tf.GraphDef.FromString(frozen_graph_bytes),
+            "input", "MobilenetV2/Predictions/Reshape_1")
+
+
+def run_graph(graph_proto, img: np.ndarray, input_node: str, output_node: str):
+  """
+  Run an example image through a MobileNet-like graph and print a summary of
+  the results to STDOUT.
+
+  graph_proto: GraphDef protocol buffer message holding serialized graph
+  img: Preprocessed (centered by dividing by 128) numpy array holding image
+  input_node: Name of input graph node
+  output_node: Name of output graph node; should produce logits
+  """
+  img_as_batch = img.reshape(tuple([1] + list(img.shape)))
+  with tf.Graph().as_default():
+    with tf.Session() as sess:
+      tf.import_graph_def(graph_proto, name="")
+      result = sess.run(output_node + ":0", {input_node + ":0": img_as_batch})
+  print("Result is {}".format(result))
+
+def main(_):
+  # Remove any detritus of previous runs of this script, but leave the temp
+  # dir in place because the user might have a shell there.
+  if not os.path.isdir(_TMP_DIR):
+    os.mkdir(_TMP_DIR)
+  _clear_dir(_SAVED_MODEL_DIR)
+  for f in _AFTER_MODEL_FILES:
+    if os.path.isfile(f):
+      os.remove(f)
+
+  # Obtain a frozen graph for a MobileNet model
+  if _USE_KERAS:
+    frozen_graph_def, input_node, output_node = get_keras_frozen_graph()
+  else:
+    frozen_graph_def, input_node, output_node = get_slim_frozen_graph()
+
+  _protobuf_to_file(frozen_graph_def, _FROZEN_GRAPH_FILE, "Frozen graph")
+
+  # Now run through some of TensorFlow's built-in graph rewrites.
+  # For that we use the undocumented Python APIs under
+  # tensorflow.tools.graph_transforms
+  after_tf_rewrites_graph_def = graph_transforms.TransformGraph(
+    frozen_graph_def,
+    inputs=[input_node],
+    outputs=[output_node],
+    # Use the set of transforms recommended in the README under "Optimizing
+    # for Deployment"
+    transforms=['strip_unused_nodes(type=float, shape="1,299,299,3")',
+                'remove_nodes(op=Identity, op=CheckNumerics)',
+                'fold_constants(ignore_errors=true)',
+                'fold_batch_norms',
+                'fold_old_batch_norms']
+  )
+
+  _protobuf_to_file(after_tf_rewrites_graph_def,
+                    _TF_REWRITES_GRAPH_FILE,
+                    "Graph after built-in TensorFlow rewrites")
+
+  # Now run the GraphDef editor's fold_batch_norms_up() rewrite
+  g = gde.Graph(after_tf_rewrites_graph_def)
+  gde.rewrite.fold_batch_norms_up(g)
+  after_gde_graph_def = g.to_graph_def(add_shapes=True)
+
+  _protobuf_to_file(after_gde_graph_def,
+                    _GDE_REWRITES_GRAPH_FILE,
+                    "Graph after fold_batch_norms_up() rewrite")
+
+  # Dump some statistics about the number of each type of op
+  print("            Number of ops in frozen graph: {}".format(len(
+    frozen_graph_def.node)))
+  print("    Number of ops after built-in rewrites: {}".format(len(
+    after_tf_rewrites_graph_def.node)))
+  print("Number of ops after fold_batch_norms_up(): {}".format(len(
+    after_gde_graph_def.node)))
+
+  # Run model before and after rewrite and compare results
+  if not os.path.exists(_PANDA_PIC_FILE):
+    print("Downloading {} to {}", _PANDA_PIC_URL, _PANDA_PIC_FILE)
+    urllib.request.urlretrieve(_PANDA_PIC_URL, _PANDA_PIC_FILE)
+  img = np.array(PIL.Image.open(_PANDA_PIC_FILE).resize((224, 224))).astype(
+    np.float) / 128 - 1
+  print("Image shape is {}".format(img.shape))
+
+  print("Frozen graph results:")
+  run_graph(frozen_graph_def, img, input_node, output_node)
+  print("Results after built-in rewrites:")
+  run_graph(after_tf_rewrites_graph_def, img, input_node, output_node)
+  print("Results after fold_batch_norms_up() rewrite:")
+  run_graph(after_gde_graph_def, img, input_node, output_node)
+
+
+if __name__ == "__main__":
+  tf.app.run()

--- a/examples/mobilenet_example.py
+++ b/examples/mobilenet_example.py
@@ -30,11 +30,10 @@ import os
 import tensorflow as tf
 import graph_def_editor as gde
 import numpy as np
-import PIL
+import PIL  # Pillow
 import shutil
 import tarfile
 import textwrap
-import keras
 import urllib.request
 
 from tensorflow.tools import graph_transforms
@@ -157,7 +156,17 @@ def run_graph(graph_proto, img: np.ndarray, input_node: str, output_node: str):
     with tf.Session() as sess:
       tf.import_graph_def(graph_proto, name="")
       result = sess.run(output_node + ":0", {input_node + ":0": img_as_batch})
-  print("Result is {}".format(result))
+
+  result = result.reshape(result.shape[1:])
+  # print("Raw result is {}".format(result))
+  sorted_indices = result.argsort()
+  # print("Top 5 indices: {}".format(sorted_indices[-5:]))
+
+  print("Rank      Label     Weight")
+  for i in range(5):
+    print("{:<10}{:<10}{}".format(i + 1, sorted_indices[-(i + 1)],
+                                  result[sorted_indices[-(i + 1)]]))
+
 
 def main(_):
   # Remove any detritus of previous runs of this script, but leave the temp

--- a/graph_def_editor/rewrite.py
+++ b/graph_def_editor/rewrite.py
@@ -139,7 +139,7 @@ def _scale_weights(weights_node: node.Node,
   for col in range(scale.shape[0]):
     indexes = [col if i == dim else slice(None)
                for i in range(len(weights.shape))]
-    scaled_weights[indexes] *= scale[col]
+    scaled_weights[tuple(indexes)] *= scale[col]
 
   # Cast down to the original precision
   scaled_weights = scaled_weights.astype(weights.dtype)

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -45,7 +45,9 @@ conda create -y --prefix ./env \
     tensorflow \
     jupyterlab \
     pytest \
-    keras
+    keras \
+    pillow \
+    nomkl
 
 echo << EOM
 Anaconda virtualenv installed in ./env.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(),
-    install_requires=['numpy<=1.14.5', 'tensorflow', 'six'],
+    install_requires=['numpy', 'tensorflow', 'six'],
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(),
-    install_requires=['numpy', 'tensorflow', 'six'],
+    install_requires=['numpy', 'tensorflow', 'six', 'pillow'],
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/tests/rewrite_test.py
+++ b/tests/rewrite_test.py
@@ -620,3 +620,69 @@ class RewriteTest(unittest.TestCase):
     # Make sure the rewrite happened
     for n in g.nodes:
       self.assertNotEqual(n.op_type, "FusedBatchNorm")
+
+  def test_fold_batch_norms_up_fused_relu6(self):
+    """
+    Test of the fold_batch_norms_up() rewrite with the pattern:
+       FusedBatchNorm => Relu6 => Conv2D
+    """
+    # Note that 3 and 5 changed to 30 and 50 to trigger Relu6
+    input_data = (
+      np.array([1., 4., 10., 50., 30., 6., -1., -4., -2., -5., -3., -6.],
+               dtype=np.float32).reshape([1, 1, 6, 2])
+    )
+    weights_data = (
+      np.array([1., 2., 3., 4., 0.1, 0.2, 0.3, 0.4],
+               dtype=np.float32).reshape([1, 2, 2, 2])
+    )
+    mean_data = np.array([10., 20.], dtype=np.float32).reshape([2])
+    variance_data = np.array([0.25, 0.5], dtype=np.float32).reshape([2])
+    beta_data = np.array([0.1, 0.6], dtype=np.float32).reshape([2])
+    gamma_data = np.array([1., 2.], dtype=np.float32).reshape([2])
+
+    # Create the non-deprecated part of the graph
+    # input -> Relu -> DepthwiseConv2D
+    tf_g = tf.Graph()
+    with tf_g.as_default():
+      in_t = tf.constant(input_data, name="input_op")
+      relu6_t = tf.nn.relu6(in_t, name="relu6_op")
+      weights_t = tf.constant(weights_data, name="weights_op")
+      _ = tf.nn.depthwise_conv2d(relu6_t, weights_t, [1, 1, 1, 1], "VALID",
+                                 name="output")
+      mean_t = tf.constant(mean_data, name="mean_op")
+      variance_t = tf.constant(variance_data, name="variance_op")
+      beta_t = tf.constant(beta_data, name="beta_op")
+      gamma_t = tf.constant(gamma_data, name="gamma_op")
+    g = gde.Graph(tf_g)
+
+    # Add fused batch norm node manually because there's no Python API to add
+    # this op directly.
+    batch_norm_node = g.add_node("batch_norm_op", "FusedBatchNorm")
+    batch_norm_node.set_inputs([g[in_t.name], g[gamma_t.name],
+                                g[beta_t.name], g[mean_t.name],
+                                g[variance_t.name]])
+    batch_norm_node.add_attr("T", tf.float32)
+    batch_norm_node.add_attr("epsilon", 0.00001)
+    batch_norm_node.add_attr("is_training", False)
+    batch_norm_node.infer_outputs()
+
+    # Redirect the input of the ReLU to our new batch norm
+    g.get_node_by_name(relu6_t.op.name).set_inputs([batch_norm_node.output(0)])
+
+    # Run the graph before and after the rewrite and compare results
+    with tf.Session(graph=g.to_tf_graph()) as sess:
+      original_outputs = sess.run("output:0")
+      relu6_inputs = sess.run("batch_norm_op:0")
+    gde.rewrite.fold_batch_norms_up(g)
+    with tf.Session(graph=g.to_tf_graph()) as sess:
+      fused_outputs = sess.run("output:0")
+    self.assertClose(original_outputs, fused_outputs, delta=1e-5)
+
+    # Make sure input to Relu6 op was large enough to trigger the "6" part.
+    print("Relu6 inputs on original graph are:\n{}".format(relu6_inputs))
+    self.assertTrue(np.any(relu6_inputs > 6.))
+
+    # Make sure the rewrite happened
+    for n in g.nodes:
+      self.assertNotEqual(n.op_type, "FusedBatchNorm")
+


### PR DESCRIPTION
This PR adds a MobileNet_V2 example to the code from the previous PR for #15.

Along the way I figured out that MobileNet V2 uses Relu6 in place of Relu and modified the rewrite to cover that case also. I also added an additional test to cover the updated rewrite.

I also tweaked the project requirements for Pip install and turned off MKL in the conda virtualenvs because MKL was causing problems on my Mac.