### PR TITLE
Switch to Python 2.7-compatible type hints

### DIFF
--- a/examples/coco_example.py
+++ b/examples/coco_example.py
@@ -97,19 +97,22 @@ _PANDA_PIC_URL = ("https://upload.wikimedia.org/wikipedia/commons/f/fe/"
                   "Giant_Panda_in_Beijing_Zoo_1.JPG")
 
 
-def _clear_dir(path: str):
+def _clear_dir(path):
+  # type: (str) -> None
   if os.path.isdir(path):
     shutil.rmtree(path)
   os.mkdir(path)
 
 
 def _protobuf_to_file(pb, path, human_readable_name):
+  # type: (Any, str, str) -> None
   with open(path, "w") as f:
     f.write(str(pb))
   print("{} written to {}".format(human_readable_name, path))
 
 
-def _fetch_or_use_cached(file_name: str, url: str):
+def _fetch_or_use_cached(file_name, url):
+  # type: (str, str) -> str
   """
   Check for a cached copy of the indicated file in our temp directory.
 
@@ -131,6 +134,7 @@ def _fetch_or_use_cached(file_name: str, url: str):
 
 
 def _get_frozen_graph():
+  # type: () -> tf.GraphDef
   """
   Obtains the starting version of the model from the TensorFlow model zoo
 
@@ -146,6 +150,7 @@ def _get_frozen_graph():
 
 
 def _build_preprocessing_graph_def():
+  # type: () -> tf.GraphDef
   """
   Build a TensorFlow graph that performs the preprocessing operations that
   need to happen before the main graph, then convert to a GraphDef.
@@ -183,6 +188,7 @@ def _build_preprocessing_graph_def():
 
 
 def _build_postprocessing_graph_def():
+  # type: () -> tf.GraphDef
   """
   Build the TensorFlow graph that performs postprocessing operations that
   should happen after the main graph.
@@ -235,7 +241,8 @@ def _build_postprocessing_graph_def():
   return result_decode_g.as_graph_def()
 
 
-def _graft_pre_and_post_processing_to_main_graph(g: gde.Graph):
+def _graft_pre_and_post_processing_to_main_graph(g):
+  # type: (gde.Graph) -> None
   """
   Attach pre- and post-processing subgraphs to the main graph.
 
@@ -271,10 +278,9 @@ def _graft_pre_and_post_processing_to_main_graph(g: gde.Graph):
   g.rename_node("decoded_detection_classes", "detection_classes")
 
 
-def _apply_graph_transform_tool_rewrites(g: gde.Graph,
-                                         input_node_names: List[str],
-                                         output_node_names: List[str]) \
-        -> tf.GraphDef:
+def _apply_graph_transform_tool_rewrites(g, input_node_names,
+                                         output_node_names):
+  # type: (gde.Graph, List[str], List[str]) -> tf.GraphDef
   """
   Use the [Graph Transform Tool](
   https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/
@@ -309,7 +315,8 @@ def _apply_graph_transform_tool_rewrites(g: gde.Graph,
   return after_tf_rewrites_graph_def
 
 
-def _graph_has_op(g: tf.Graph, op_name: str):
+def _graph_has_op(g, op_name):
+  # type: (tf.Graph, str) -> bool
   """
   A method that really ought to be part of `tf.Graph`. Returns true of the
   indicated graph has an op by the indicated name.
@@ -318,7 +325,8 @@ def _graph_has_op(g: tf.Graph, op_name: str):
   return any(op_name == o.name for o in all_ops_in_graph)
 
 
-def _run_coco_graph(graph_proto: tf.GraphDef, img: np.ndarray):
+def _run_coco_graph(graph_proto, img):
+  # type: (tf.GraphDef, np.ndarray) -> None
   """
   Run an example image through a TensorFlow graph and print a summary of
   the results to STDOUT.
@@ -410,7 +418,7 @@ def main(_):
   after_gde_graph_def = g.to_graph_def(add_shapes=True)
   _protobuf_to_file(after_gde_graph_def,
                     _GDE_REWRITES_GRAPH_FILE,
-                    "Graph after fold_batch_norms_up() rewrite")
+                    "Graph after GraphDef Editor rewrites")
 
   # Dump some statistics about the number of each type of op
   print("            Number of ops in frozen graph: {}".format(len(

--- a/examples/mobilenet_example.py
+++ b/examples/mobilenet_example.py
@@ -65,19 +65,22 @@ _PANDA_PIC_URL = ("https://upload.wikimedia.org/wikipedia/commons/f/fe/"
                   "Giant_Panda_in_Beijing_Zoo_1.JPG")
 _PANDA_PIC_FILE = _TMP_DIR + "/panda.jpg"
 
-def _clear_dir(path: str):
+def _clear_dir(path):
+  # type: (str) -> None
   if os.path.isdir(path):
     shutil.rmtree(path)
   os.mkdir(path)
 
 
 def _protobuf_to_file(pb, path, human_readable_name):
+  # type: (Any, str, str) -> None
   with open(path, "w") as f:
     f.write(str(pb))
   print("{} written to {}".format(human_readable_name, path))
 
 
 def get_keras_frozen_graph():
+  # type: () -> Tuple[tf.GraphDef, str, str]
   """
   Generate a frozen graph for the Keras MobileNet_v2 model.
 
@@ -120,6 +123,7 @@ def get_keras_frozen_graph():
 
 
 def get_slim_frozen_graph():
+  # type: () -> Tuple[tf.GraphDef, str, str]
   """
   Obtains a MobileNet_v2 model from the TensorFlow model zoo
 
@@ -144,7 +148,8 @@ def get_slim_frozen_graph():
             "input", "MobilenetV2/Predictions/Reshape_1")
 
 
-def run_graph(graph_proto, img: np.ndarray, input_node: str, output_node: str):
+def run_graph(graph_proto, img, input_node, output_node):
+  # type: (tf.GraphDef, np.ndarray, str, str) -> None
   """
   Run an example image through a MobileNet-like graph and print a summary of
   the results to STDOUT.
@@ -233,7 +238,11 @@ def main(_):
     print("Downloading {} to {}".format(_PANDA_PIC_URL, _PANDA_PIC_FILE))
     urllib.request.urlretrieve(_PANDA_PIC_URL, _PANDA_PIC_FILE)
   img = np.array(PIL.Image.open(_PANDA_PIC_FILE).resize((224, 224))).astype(
-    np.float) / 128 - 1
+    np.float) # / 128 # - 1
+  # Normalize each channel
+  channel_means = np.mean(img, axis=(0, 1))
+
+  print("Channel means are: {}".format(channel_means))
   print("Image shape is {}".format(img.shape))
 
   print("Frozen graph results:")

--- a/graph_def_editor/graph.py
+++ b/graph_def_editor/graph.py
@@ -48,7 +48,8 @@ class GraphVisitor(object):
   """
   Visitor callback for various graph traversals
   """
-  def visit_node(self, n: 'node.Node'):
+  def visit_node(self, n):
+    # type: (node.Node) -> None
     raise NotImplementedError()
 
 
@@ -57,7 +58,8 @@ class SaverInfo(object):
   Object to encapsulate information about a `tf.train.Saver` object that can
   reconstitute the variable values for this graph.
   """
-  def __init__(self, path: str, saver_def: tf.train.SaverDef):
+  def __init__(self, path, saver_def):
+    # type: (str, tf.train.SaverDef) -> None
     """
     Args:
       path: Path to the location of serialized variable information on disk
@@ -73,11 +75,10 @@ class SignatureInfo(object):
   AKA signatures.
   """
   def __init__(self):
-    self._signature_defs = {}  # Dict[str, meta_graph_pb2.SignatureDef]
+    self._signature_defs = {}  # type: Dict[str, meta_graph_pb2.SignatureDef]
 
-  def add_signature_def(self,
-                        name: str,
-                        signature_def: meta_graph_pb2.SignatureDef):
+  def add_signature_def(self, name, signature_def):
+    # type: (str, meta_graph_pb2.SignatureDef) -> None
     """
     Add a signature to the set of entry points.
 
@@ -92,6 +93,7 @@ class SignatureInfo(object):
 
   @property
   def signature_defs(self):
+    # type: () -> Dict[str, Any]
     return self._signature_defs
 
 
@@ -108,11 +110,14 @@ class Graph(object):
                   collections
   """
 
-  def __init__(self, g: Union[tf.Graph, tf.GraphDef] = None,
-               name: str = None,
-               collections: Dict[str, meta_graph_pb2.CollectionDef] = None,
-               saver_info: SaverInfo = None,
-               signature_info: SignatureInfo = None):
+  def __init__(
+          self,
+          g = None, # type: Union[tf.Graph, tf.GraphDef]
+          name = None, # type: str
+          collections = None, # type: Dict[str, meta_graph_pb2.CollectionDef]
+          saver_info = None, # type: SaverInfo
+          signature_info = None # type: SignatureInfo
+          ):
     """
     Wrap a tf.GraphDef protocol buffer in a Graph object.
 
@@ -199,8 +204,8 @@ class Graph(object):
   def has_passthrough_saver(self):
     return self._passthrough_saver is not None
 
-  def add_node_from_node_def(self, node_def: tf.NodeDef,
-                             set_inputs: bool = False) -> 'node.Node':
+  def add_node_from_node_def(self, node_def, set_inputs = False):
+    # type: (tf.NodeDef, bool) -> node.Node
     """
     Unpack a `tf.NodeDef` protobuf into a mutable `Node` object.'
 
@@ -224,9 +229,10 @@ class Graph(object):
 
   def add_collection_from_collection_def(
           self,
-          collection_name: str,
-          collection_def: meta_graph_pb2.CollectionDef,
-          validate_name: bool = True):
+          collection_name,
+          collection_def,
+          validate_name = True):
+    # type: (str, meta_graph_pb2.CollectionDef, bool) -> None
     """
     Unpack a `tf.MetaGraphDef.CollectionDefEntry` of serialized variables 
     into a collection of variables in this graph. The collection must not exist. 
@@ -264,7 +270,8 @@ class Graph(object):
     else:
       raise ValueError("Unknown collection with name: {}".format(collection_name))
 
-  def __getitem__(self, name: str) -> Union[tensor.Tensor, 'node.Node']:
+  def __getitem__(self, name) :
+    # type: (str) -> Union[tensor.Tensor, 'node.Node']
     """
     Convenience method to retrieve a node or tensor of the graph by name
 
@@ -284,7 +291,8 @@ class Graph(object):
     else:
       raise ValueError("No node or tensor '{}' found in graph".format(name))
 
-  def get_node_by_name(self, name: str) -> 'node.Node':
+  def get_node_by_name(self, name):
+    # type: (str) -> node.Node
     """
     Retrieve a node in the graph by name.
 
@@ -298,7 +306,8 @@ class Graph(object):
     else:
       raise ValueError("No node '{}' found in graph".format(name))
 
-  def contains_node(self, name: str) -> bool:
+  def contains_node(self, name):
+    # type: (str) -> bool
     """
     Returns true if the graph has a node by the indicated name. Exact string
     match.
@@ -308,8 +317,12 @@ class Graph(object):
                        "{}".format(type(name)))
     return name in self._node_name_to_node.keys()
 
-  def add_node(self, name: str, op_name: str, uniquify_name: bool = False) -> \
-          'node.Node':
+  def add_node(self,
+               name, # type: str
+               op_name, # type: str
+               uniquify_name = False # type: bool
+               ):
+    # type: (...) -> node.Node
     """
     Add a new, empty node to the graph.
     Args:
@@ -336,9 +349,12 @@ class Graph(object):
     self.increment_version_counter()
     return ret
 
-  def add_node_from_node_def(self, node_def: tf.NodeDef,
-                             set_inputs: bool = False,
-                             set_control_inputs: bool = False) -> 'node.Node':
+  def add_node_from_node_def(self,
+                             node_def, # type: tf.NodeDef
+                             set_inputs = False, # type: bool
+                             set_control_inputs = False # type: bool
+                             ):
+    # type: (...) -> node.Node
     """
     Adds a new node to the graph, populating fields of the node from a
     `tf.NodeDef` protocol buffer.
@@ -370,7 +386,8 @@ class Graph(object):
     # Don't need to increment version counter; add_node() already did that.
     return ret
 
-  def remove_node_by_name(self, name: str, check_for_refs: bool = True):
+  def remove_node_by_name(self, name, check_for_refs = True):
+    # type: (str, str) -> None
     """
     Removes the indicated node from this graph and from any collections in
     this graph.
@@ -403,6 +420,7 @@ class Graph(object):
     # calculated dynamically by iterating over nodes.
 
   def rename_node(self, old_name, new_name):
+    # type: (str, str) -> None
     """
     Change the name of a node in the graph.
 
@@ -420,7 +438,8 @@ class Graph(object):
     self._node_name_to_node[new_name] = n
     self.increment_version_counter()
 
-  def add_variable(self, name: str) -> variable.Variable:
+  def add_variable(self, name):
+    # type: (str) -> variable.Variable
     """
     Adds a new variable to the graph.
 
@@ -437,7 +456,8 @@ class Graph(object):
     return v
 
   def add_variable_from_variable_def(self, variable_def,
-                                     skip_if_present: bool = False):
+                                     skip_if_present = False):
+    # type: (Any, bool) -> None
     """
     Adds a new variable to the graph and populates the fields of the
     corresponding Variable object according to a protocol buffer message.
@@ -460,7 +480,8 @@ class Graph(object):
   def variable_names(self):
     return self._variable_name_to_variable.keys()
 
-  def get_variable_by_name(self, name: str) -> variable.Variable:
+  def get_variable_by_name(self, name):
+    # type: (str) -> variable.Variable
     """
     Fetch a variable by its variable name.
 
@@ -472,7 +493,8 @@ class Graph(object):
     """
     return self._variable_name_to_variable[name]
 
-  def _name_in_use(self, name: str) -> bool:
+  def _name_in_use(self, name):
+    # type: (str) -> bool
     """Check whether a name is in use, using the same collision semantics as
     TensorFlow: Exact lowercase string match.
 
@@ -483,7 +505,8 @@ class Graph(object):
     """
     return name.lower() in [k.lower() for k in self._node_name_to_node.keys()]
 
-  def unique_name(self, name: str):
+  def unique_name(self, name):
+    # type: (str) -> str
     """Emulate the behavior of the method by the same name in `tf.Graph`.
 
     Does *not* emulate the `name_stack` field of `tf.Graph`.
@@ -516,11 +539,13 @@ class Graph(object):
     return new_name
 
   @property
-  def node_names(self) -> Iterable['node.Node']:
+  def node_names(self):
+    # type: () -> Iterable[node.Node]
     return self._node_name_to_node.keys()
 
   @property
-  def nodes(self) -> Tuple['node.Node']:
+  def nodes(self):
+    # type: () -> Tuple[node.Node]
     """
     Returns:
       A list of all nodes, both immutable and mutable, present in the graph
@@ -530,6 +555,7 @@ class Graph(object):
 
   @property
   def tensors(self):
+    # type: () -> List[tensor.Tensor]
     """
     Return a list of all the tensors which are input or output of an op in
     the graph.
@@ -539,7 +565,8 @@ class Graph(object):
       ts += op.outputs
     return ts
 
-  def contains_tensor(self, tensor_name: str) -> bool:
+  def contains_tensor(self, tensor_name):
+    # type: (str) -> bool
     """
     Returns true if the graph has a tensor by the indicated name. Exact string
     match.
@@ -561,7 +588,8 @@ class Graph(object):
       else:
         return True
 
-  def get_tensor_by_name(self, tensor_name: str, error_msg: str = None):
+  def get_tensor_by_name(self, tensor_name, error_msg = None):
+    # type: (str, str) -> tensor.Tensor
     """
     Retrieve a tensor by human-readable name.
 
@@ -592,7 +620,8 @@ class Graph(object):
       ))
     return n.output(output_ix)
 
-  def to_graph_def(self, add_shapes: bool = True):
+  def to_graph_def(self, add_shapes = True):
+    # type: (bool) -> tf.GraphDef
     """
     Args:
       add_shapes: If True, add the special "_output_shapes" attribute with
@@ -608,6 +637,7 @@ class Graph(object):
     return ret
 
   def to_tf_graph(self):
+    # type: () -> tf.Graph
     """
     Converts this graph into a new TensorFlow `Graph`. Also takes care of
     variables.
@@ -621,9 +651,8 @@ class Graph(object):
       util.load_variables_to_tf_graph(self)
     return ret
 
-  def to_saved_model(self, saved_model_path: str,
-                     tags: Iterable[str] = None) -> \
-          saved_model_pb2.SavedModel:
+  def to_saved_model(self, saved_model_path, tags = None):
+    # type: (str, Iterable[str]) -> saved_model_pb2.SavedModel
     """
     Writes this graph out as a TensorFlow SavedModel on disk.
 
@@ -760,6 +789,7 @@ class Graph(object):
 
   @property
   def version(self):
+    # type: () -> int
     """
     Returns a counter that goes up every time this graph is changed.
     """
@@ -767,6 +797,7 @@ class Graph(object):
 
   @property
   def frozen(self):
+    # type: () -> bool
     """
     True if the graph is configured to raise an exception on any structural
     modification.
@@ -775,6 +806,7 @@ class Graph(object):
 
   @frozen.setter
   def frozen(self, value):
+    # type: (bool) -> None
     self._frozen = value
 
   def increment_version_counter(self):
@@ -790,7 +822,8 @@ class Graph(object):
     self._head_name_to_coloc_group = None
     self._collection_name_to_type = None
 
-  def get_collection_by_name(self, name: str) -> Iterable[Any]:
+  def get_collection_by_name(self, name):
+    # type: (str) -> Iterable[Any]
     """Fetch the contents of a collection, similarly to the method in
     `tf.Graph` by the same name.
 
@@ -828,6 +861,7 @@ class Graph(object):
       raise ValueError("Unknown collection type '{}'".format(coll_type))
 
   def _build_collection_name_to_type(self):
+    # type: () -> None
     self._collection_name_to_type = {}
     passthrough_collection_names = set(self._passthrough_collections.keys())
     variable_collection_names = set()
@@ -863,18 +897,21 @@ class Graph(object):
     _add(node_collection_names, "node")
 
   def get_all_collection_keys(self):
+    # type: () -> Iterable[str]
     """Returns the keys associated with all collections stored in this object"""
     if self._collection_name_to_type is None:
       self._build_collection_name_to_type()
     return self._collection_name_to_type.keys()
 
-  def _get_next_id(self) -> int:
+  def _get_next_id(self):
+    # type: () -> int
     """Generates and returns a unique integer ID *within this graph*."""
     ret = self._next_id
     self._next_id = ret + 1
     return ret
 
-  def node_to_frame_names(self, n: 'node.Node') -> Tuple[str]:
+  def node_to_frame_names(self, n):
+    # type: (node.Node) -> Tuple[str]
     """
     Generates (or uses a cached copy of) a map from graph node to the name of
     the associated control flow frame(s).
@@ -917,7 +954,9 @@ class Graph(object):
       n: Node in this graph
 
     Returns:
-      Dictionary mapping from nodes in this graph to the names of one or
+      TODO: Fix this documentation
+      Dictionary mapping from nodes in this graph to the names of
+      one or
       more nested frames that will be active when reaching this node.
       The returned value is only valid until this graph is modified, either
       by modifying the link structure of the graph or by changing the
@@ -928,7 +967,8 @@ class Graph(object):
       self._generate_node_to_frame_name()
     return self._node_to_frame_names[n]
 
-  def frame_name_to_nodes(self, frame_name: str) -> Tuple['node.Node']:
+  def frame_name_to_nodes(self, frame_name):
+    # type: (str) -> Tuple[node.Node]
     """
     Performs the inverse mapping of node_to_frame_name().
 
@@ -943,7 +983,8 @@ class Graph(object):
       self._generate_node_to_frame_name()
     return self._frame_name_to_nodes[frame_name]
 
-  def get_frame_names(self) -> Tuple[str]:
+  def get_frame_names(self):
+    # type: () -> Tuple[str]
     """
     Returns:
       Tuple of all the unique names of frames that occur in this graph.
@@ -952,8 +993,11 @@ class Graph(object):
       self._generate_node_to_frame_name()
     return self._frame_name_to_nodes.keys()
 
-  def breadth_first_visitor(self, visitor: GraphVisitor,
-                            starting_nodes: Iterable['node.Node'] = None):
+  def breadth_first_visitor(self,
+                            visitor, # type: GraphVisitor
+                            starting_nodes = None # type: Iterable[node.Node]
+                            ):
+    # type: (...) -> None
     """
     Visit all nodes reachable from a starting set in the order of a
     breadth-first traversal. Invokes a callback at each node visited.
@@ -987,7 +1031,9 @@ class Graph(object):
             enqueued_nodes.add(out_node)
 
   def infer_shapes_and_dtypes(self,
-                              starting_nodes: Iterable['node.Node'] = None):
+                              starting_nodes = None # type: Iterable[node.Node]
+                              ):
+    # type: (...) -> None
     """
     Visit all nodes reachable from a starting set in the order of a
     breadth-first traversal, invoking shape and type inference.
@@ -1051,7 +1097,8 @@ class Graph(object):
     }
 
   @property
-  def colocation_groups(self) -> Dict[str, FrozenSet['node.Node']]:
+  def colocation_groups(self):
+    # type: () -> Dict[str, FrozenSet[node.Node]]
     """
     Generate a table of all groups of nodes that must be on the same device
     according to collocation constrains in the underlying NodeDefs.
@@ -1073,7 +1120,8 @@ class Graph(object):
     return self._head_name_to_coloc_group
 
   @property
-  def signatures(self) -> Dict[str, meta_graph_pb2.SignatureDef]:
+  def signatures(self):
+    # type: () -> Dict[str, meta_graph_pb2.SignatureDef]
     """
     Returns a map from signature name to signature definition. Changes to
     this map will be reflected in this object.
@@ -1081,9 +1129,12 @@ class Graph(object):
     return self._signatures.signature_defs
 
 
-def saved_model_to_graph(saved_model_path: str, tag: str = None,
-                         include_saver: bool = True,
-                         include_signatures: bool = True) -> 'Graph':
+def saved_model_to_graph(saved_model_path, # type: str
+                         tag = None, # type: str
+                         include_saver = True, # type: bool
+                         include_signatures = True # type: bool
+                         ):
+  # type: (...) -> Graph
   """
   Load the contents of a TensorFlow SavedModel into a Graph object.
 
@@ -1163,6 +1214,7 @@ def saved_model_to_graph(saved_model_path: str, tag: str = None,
 
 
 def _decode_graph(graph_def):
+  # type: (tf.GraphDef) -> Dict[str, List[Tuple[tf.DType, tf.TensorShape]]]
   """
   Use public TensorFlow APIs to decode the important information that is not
   explicitly stored in the GraphDef proto, but which must be inferred from the
@@ -1194,9 +1246,8 @@ def _decode_graph(graph_def):
   return output_map
 
 
-def _extract_collection_defs(meta_graph: tf.MetaGraphDef) -> Dict[
-  str, meta_graph_pb2.CollectionDef]:
-
+def _extract_collection_defs(meta_graph):
+  # type: (tf.MetaGraphDef) -> Dict[str, meta_graph_pb2.CollectionDef]
   collections = {}
   for collection_name in meta_graph.collection_def:
     if type(collection_name) is not str:
@@ -1212,7 +1263,8 @@ def _extract_collection_defs(meta_graph: tf.MetaGraphDef) -> Dict[
   return collections
 
 
-def _decode_tensor_name(tensor_name: str, error_msg: str):
+def _decode_tensor_name(tensor_name, error_msg):
+  # type: (str, str) -> Tuple[str, int]
   """
   Args:
     tensor_name: TensorFlow-format name ('node name:input num', or 'node
@@ -1239,10 +1291,13 @@ def _decode_tensor_name(tensor_name: str, error_msg: str):
   return node_name, output_ix
 
 
-def _duplicate_collection_error_str(name: str,
-                                    passthrough_collection_names: Set[str],
-                                    variable_collection_names: Set[str],
-                                    node_collection_names: Set[str]):
+def _duplicate_collection_error_str(
+        name, # type: str
+        passthrough_collection_names, # type: Set[str]
+        variable_collection_names, # type: Set[str]
+        node_collection_names # type: Set[str]
+  ):
+  # type: (...) -> str
   """
   Generate an error string for the case where a collection ends up being of
   multiple types simultaneously.
@@ -1260,6 +1315,7 @@ def _duplicate_collection_error_str(name: str,
 
 
 def _vars_dir_for_saved_model(saved_model_path: str) -> str:
+  # type: (str) -> str
   """
   Args:
     saved_model_path: Root directory of a SavedModel on disk

--- a/graph_def_editor/node.py
+++ b/graph_def_editor/node.py
@@ -47,8 +47,13 @@ class Node(object):
   Accumulates the parameters of the node and can produce an appropriate
   tf.NodeDef protobuf on demand.
   """
-  def __init__(self, g: 'graph.Graph', node_id: int, name: str, op_name: str,
-               device: str = ""):
+  def __init__(self,
+               g, # type: graph.Graph
+               node_id, # type: int
+               name, # type: int
+               op_name, # type: str
+               device = "" # type: str
+               ):
     """
     This constructor should only be called from methods of the Graph
     class.
@@ -75,17 +80,20 @@ class Node(object):
     self._collection_names = set()  # Set[str]
 
   def __repr__(self):
+    # type: () -> str
     return "Node[{}|{}]".format(self.name, self.op_type)
 
   @property
-  def name(self) -> str:
+  def name(self):
+    # type: () -> str
     """
     Returns:
        Unique name of the node that this Node represents
     """
     return self._name
 
-  def _change_name(self, new_name: str):
+  def _change_name(self, new_name):
+    # type: (str) -> None
     """
     THIS METHOD SHOULD ONLY BE CALLED BY THE PARENT GRAPH
 
@@ -97,14 +105,16 @@ class Node(object):
     self._name = new_name
 
   @property
-  def op_type(self) -> str:
+  def op_type(self):
+    # type: () -> str
     """
     Returns:
       Name of the TensorFlow op type that this Node represents
     """
     return self._op_name
 
-  def change_op_type(self, new_op_type: str):
+  def change_op_type(self, new_op_type):
+    # type: (str) -> None
     """
     Change the op type of this node. Does NOT rerun shape or type inference.
 
@@ -116,7 +126,8 @@ class Node(object):
     self._op_name = new_op_type
 
   @property
-  def graph(self) -> 'graph.Graph':
+  def graph(self):
+    # type: () -> graph.Graph
     """
     Returns:
       `gde.Graph` object representing the graph in which this Node resides.
@@ -124,7 +135,8 @@ class Node(object):
     return self._graph
 
   @property
-  def id_in_graph(self) -> int:
+  def id_in_graph(self):
+    # type: () -> int
     """
     Returns this node's unique integer id within the parent graph. Useful for
     sorting nodes in an arbitrary but consistent order.
@@ -132,6 +144,7 @@ class Node(object):
     return self._id
 
   def _remove_from_graph(self):
+    # type: () -> None
     """
     THIS METHOD TO BE CALLED ONLY BY THE PARENT GRAPH.
 
@@ -143,7 +156,8 @@ class Node(object):
     # to the graph, only to the node
 
   @property
-  def outputs(self) -> Tuple[tensor.Tensor]:
+  def outputs(self):
+    # type: () -> Tuple[tensor.Tensor]
     """
     Returns:
       Tuple (i.e. immutable list) of `gde.Tensor` objects representing the
@@ -154,7 +168,8 @@ class Node(object):
       raise ValueError("Outputs of {} have not been set".format(self))
     return tuple(self._outputs)
 
-  def output(self, index: int) -> tensor.Tensor:
+  def output(self, index):
+    # type: (int) -> tensor.Tensor
     """
     Args:
       index: Index of an output of the node
@@ -166,7 +181,8 @@ class Node(object):
     return self._outputs[index]
 
   @property
-  def inputs(self) -> Tuple[tensor.Tensor]:
+  def inputs(self):
+    # type: () -> Tuple[tensor.Tensor]
     """
     Returns:
       Tuple (i.e. immutable list) of `gde.Tensor` objects representing the
@@ -175,7 +191,8 @@ class Node(object):
     """
     return tuple(self._inputs)
 
-  def replace_input(self, index: int, new_input: tensor.Tensor):
+  def replace_input(self, index, new_input):
+    # type: (int, tensor.Tensor) -> None
     """
     Replace an existing input of this node with the specified tensor. Roughly
     equivalent to `tf.Operator._update_input()`.
@@ -198,7 +215,8 @@ class Node(object):
     self._inputs[index] = new_input
     self._graph.increment_version_counter()
 
-  def set_inputs(self, new_inputs: Iterable[tensor.Tensor]):
+  def set_inputs(self, new_inputs):
+    # type: (Iterable[tensor.Tensor]) -> None
     """
     Set all inputs at once, removing anything that was there previously.
 
@@ -213,7 +231,8 @@ class Node(object):
     self._graph.increment_version_counter()  # New edges added to graph
 
   @property
-  def control_inputs(self) -> Tuple['Node']:
+  def control_inputs(self):
+    # type: () -> Tuple[Node]
     """
     Returns:
       Tuple (i.e. immutable list) of `gde.Node` objects representing the
@@ -222,7 +241,8 @@ class Node(object):
     return tuple(self._control_inputs)
 
   @property
-  def device(self) -> str:
+  def device(self):
+    # type: () -> str
     """
     Returns:
       TensorFlow device placement string describing where this node should be
@@ -231,11 +251,13 @@ class Node(object):
     return self._device
 
   @device.setter
-  def device(self, value: str):
+  def device(self, value):
+    # type: (str) -> None
     self._device = value
 
   @property
-  def colocation_groups(self) -> List[str]:
+  def colocation_groups(self):
+    # type: () -> List[str]
     """
     **A word about colocation groups:**
 
@@ -321,7 +343,8 @@ class Node(object):
     return tuple(self._colocation_groups)
 
   @colocation_groups.setter
-  def colocation_groups(self, value: Iterable[str]):
+  def colocation_groups(self):
+    # type: (Iterable[str]) -> None
     """
     Setter for the `colocation_groups` property.
 
@@ -339,7 +362,8 @@ class Node(object):
     # generated about colocation constraints.
     self.graph.increment_version_counter()
 
-  def add_colocation_group(self, head_node_name: str, validate: bool = True):
+  def add_colocation_group(self, head_node_name, validate = True):
+    # type: (str, bool) -> None
     """
     Add a new colocation group to this Node.
 
@@ -365,7 +389,8 @@ class Node(object):
         head_node_name))
     self._colocation_groups.append(head_node_name)
 
-  def to_node_def(self, target: tf.NodeDef = None, add_shapes: bool = True):
+  def to_node_def(self, target = None, add_shapes = True):
+    # type: (tf.NodeDef, bool) -> tf.NodeDef
     """
     Args:
       target: optional preallocated, empty NodeDef object to fill in. If not
@@ -405,7 +430,8 @@ class Node(object):
       )
     return target
 
-  def get_attr(self, key: str) -> Any:
+  def get_attr(self, key):
+    # type: (str) -> Any
     """
     Retrieve the value of an attribute by name.
 
@@ -434,7 +460,8 @@ class Node(object):
     else:
       return ret
 
-  def has_attr(self, key: str) -> bool:
+  def has_attr(self, key):
+    # type: (str) -> bool
     """
     Args:
       key: String name of a potential attribute
@@ -443,7 +470,8 @@ class Node(object):
     """
     return key in self._attributes
 
-  def get_attr_keys(self) -> Tuple[str]:
+  def get_attr_keys(self):
+    # type: () -> Tuple[str]
     """
     Returns:
       Tuple (immutable list) of the keys of all attributes currently present
@@ -451,8 +479,12 @@ class Node(object):
     """
     return tuple([p[0] for p in self._attributes])
 
-  def add_attr(self, key: str, value: Any,
-               validate_colocation_groups: bool = False):
+  def add_attr(self,
+               key, # type: str
+               value, # type: Any
+               validate_colocation_groups = False # type: bool
+               ):
+    # type: (...) -> None
     """Add a single attribute to the underlying NodeDef's attr list.
 
     If you use this method to set the special "_class" attribute,
@@ -491,7 +523,8 @@ class Node(object):
       # Make sure attributes appear in protobuf in the order added
       self._attributes.append((key, value))
 
-  def _update_shapes(self, new_shapes: List[tf.TensorShape]):
+  def _update_shapes(self, new_shapes):
+    # type: (List[tf.TensorShape]) -> None
     """
     Put a set of output shapes in place without changing dtypes. Raises an
     error if doing so would change the number of outputs. Sets dtypes to None
@@ -511,8 +544,12 @@ class Node(object):
       for i in range(len(new_shapes)):
         self._outputs[i].shape = new_shapes[i]
 
-  def replace_attr(self, key: str, value: Any,
-                   validate_colocation_groups: bool = False):
+  def replace_attr(self,
+                   key, # type: str
+                   value, # type: Any
+                   validate_colocation_groups = False # type: bool
+                   ):
+    # type: (...) -> None
     """
     Replace an existing attribute in the underlying NodeDef's attr list,
     without changing the order of the list.
@@ -552,15 +589,18 @@ class Node(object):
           break
 
   def clear_attrs(self):
+    # type: () -> None
     """
     Remove any attributes that are attached to this node.
     """
     self._attributes.clear()
 
   def _attr_names(self):
+    # type: () -> List[str]
     return [a[0] for a in self._attributes]
 
-  def set_control_inputs(self, new_control_inputs: Iterable['Node']):
+  def set_control_inputs(self, new_control_inputs):
+    # type: (Iterable[Node]) -> None
     """
     Set all control inputs at once, removing anything that was there
     previously.
@@ -570,9 +610,8 @@ class Node(object):
     """
     self._control_inputs = list(new_control_inputs)
 
-  def set_outputs_from_pairs(self,
-                             new_outputs: List[Tuple[tf.DType,
-                                                     tf.TensorShape]]):
+  def set_outputs_from_pairs(self, new_outputs):
+    # type: (List[Tuple[tf.DType, tf.TensorShape]) -> None
     """
     Set all outputs at once, removing anything that was there previously.
 
@@ -604,6 +643,7 @@ class Node(object):
     self._graph.increment_version_counter()  # Just in case
 
   def infer_outputs(self):
+    # type: () -> None
     """
     Use TensorFlow's shape and dtype inference to determine the number of
     outputs as well as their shapes and dtypes, based on the node's op type
@@ -647,8 +687,8 @@ class Node(object):
 
         # TODO(frreiss): If this op has a "T" attribute, set that too.
 
-  def set_inputs_from_strings(self, new_inputs: Iterable[str],
-                              set_control_inputs: bool = True):
+  def set_inputs_from_strings(self, new_inputs, set_control_inputs = True):
+    # type: (Iterable[str], bool) -> None
     """
     Set all input at once, converting TensorFlow string-format inputs into
     `Tensor` objects. All nodes referenced in the input strings must be
@@ -668,14 +708,16 @@ class Node(object):
     self._graph.increment_version_counter()  # New edges added to graph
 
   @property
-  def collection_names(self) -> AbstractSet[str]:
+  def collection_names(self):
+    # type: () -> AbstractSet[str]
     """
     Returns the names of all collections this node is a member of in the
     parent graph.
     """
     return frozenset(self._collection_names)
 
-  def add_to_collection(self, collection_name: str):
+  def add_to_collection(self, collection_name):
+    # type: (str) -> None
     """
     Add the node to the indicated collection.
     """
@@ -686,6 +728,7 @@ class Node(object):
       self._graph.increment_version_counter()
 
   def remove_from_collections(self):
+    # type: () -> None
     """
     Remove this node from amy collections that it is currently a member of.
     """
@@ -696,7 +739,8 @@ class Node(object):
 # Stuff below this line is private to this file.
 
 
-def _canonicalize_output_name(name: str):
+def _canonicalize_output_name(name):
+  # type: (str) -> str
   """
   Args:
     name: Name for an op output as it would appear in the protocol buffer
@@ -710,8 +754,10 @@ def _canonicalize_output_name(name: str):
     return name + ":0"
 
 
-def _decode_inputs(inputs: Iterable[str], g: 'graph.Graph') -> List[
-  tensor.Tensor]:
+def _decode_inputs(inputs, # type: Iterable[str]
+                   g # type: graph.Graph
+  ):
+  # type: (...) -> List[tensor.Tensor]
   """
   Extract and decode the inputs in a list of TensorFlow input specification
   strings.
@@ -744,8 +790,10 @@ def _decode_inputs(inputs: Iterable[str], g: 'graph.Graph') -> List[
   return input_tensors
 
 
-def _decode_control_inputs(inputs: Iterable[str], g: 'graph.Graph') -> List[
-  Node]:
+def _decode_control_inputs(inputs, # type: Iterable[str]
+                           g # type: graph.Graph
+                           ):
+  # type: (...) -> List[Node]
   """
   Extract and decode the control inputs in a list of TensorFlow input
   specification strings.
@@ -797,7 +845,8 @@ def _validate_colocation_group_attr(value: Any) -> List[str]:
   return ret
 
 
-def _validate_output_shapes_attr(value: Any) -> List[tf.TensorShape]:
+def _validate_output_shapes_attr(value):
+  # type: (Any) -> List[tf.TensorShape]
   """
   Validate a potential value for the special "_output_shapes" attribute.
 

--- a/graph_def_editor/select.py
+++ b/graph_def_editor/select.py
@@ -175,7 +175,11 @@ def filter_ops(ops, positive_filter):
   return ops
 
 
-def filter_ops_by_optype(ops, op_types: Union[str, List[str], Tuple[str]]):
+def filter_ops_by_optype(
+        ops,
+        op_types # type: Union[str, List[str], Tuple[str]]
+  ):
+  # type: (...) -> List[node.Node]
   """
   Filter out all ops that do not have op types in a provided list of types.
 


### PR DESCRIPTION
This PR implements the first part of #32, switching the type hints from Python 3 syntax to the Python 2.7-compatible syntax. Other parts of #32 are not implemented in this PR.