### PR TITLE
Fix compatibility issues with Python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 env
 *.swp
 */__pycache__
+*.pyc
 *.iml
 test.out
 example.out

--- a/graph_def_editor/graph.py
+++ b/graph_def_editor/graph.py
@@ -22,7 +22,9 @@ import datetime
 from distutils import dir_util
 import os
 import tensorflow as tf
-from typing import Tuple, Dict, FrozenSet, Iterable, Union, Set, Any
+import sys
+if sys.version >= '3':
+  from typing import Tuple, Dict, FrozenSet, Iterable, Union, Set, Any
 
 from graph_def_editor import node, util, tensor, variable
 
@@ -270,7 +272,7 @@ class Graph(object):
     else:
       raise ValueError("Unknown collection with name: {}".format(collection_name))
 
-  def __getitem__(self, name) :
+  def __getitem__(self, name):
     # type: (str) -> Union[tensor.Tensor, 'node.Node']
     """
     Convenience method to retrieve a node or tensor of the graph by name
@@ -1045,7 +1047,9 @@ class Graph(object):
          children in order by parent node.
     """
     class _MyVisitor(GraphVisitor):
-      def visit_node(self, cur_node: 'node.Node'):
+      def visit_node(self,
+                     cur_node # type: node.Node
+                     ):
         cur_node.infer_outputs()
     self.breadth_first_visitor(_MyVisitor(), starting_nodes)
 
@@ -1068,7 +1072,9 @@ class Graph(object):
         self.new_node_to_frame_names = {}
         self.new_frame_name_to_nodes = {}
 
-      def visit_node(self, cur_node: 'node.Node'):
+      def visit_node(self,
+                     cur_node # type: node.Node
+                     ):
         if cur_node.op_type in ["Enter", "RefEnter"]:
           # Entering a while loop. Push a frame name onto the virtual stack
           if _FRAME_NAME_ATTR not in cur_node.get_attr_keys():
@@ -1314,7 +1320,9 @@ def _duplicate_collection_error_str(
     "{}".format(name, types))
 
 
-def _vars_dir_for_saved_model(saved_model_path: str) -> str:
+def _vars_dir_for_saved_model(
+        saved_model_path # type: str
+  ):
   # type: (str) -> str
   """
   Args:

--- a/graph_def_editor/graph.py
+++ b/graph_def_editor/graph.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import datetime
 from distutils import dir_util
 import os
+from six import string_types
 import tensorflow as tf
 import sys
 if sys.version >= '3':
@@ -283,7 +284,7 @@ class Graph(object):
     Returns the named item as a `gde.Node` or `gde.Tensor` object. If there
     is a conflict between node and tensor names, node names win.
     """
-    if not isinstance(name, str):
+    if not isinstance(name, string_types):
       raise TypeError("name must be a string; got type {}".format(type(name)))
 
     if self.contains_node(name):
@@ -314,7 +315,7 @@ class Graph(object):
     Returns true if the graph has a node by the indicated name. Exact string
     match.
     """
-    if not isinstance(name, str):
+    if not isinstance(name, string_types):
       raise ValueError("Node name argument is not a string, but is of type "
                        "{}".format(type(name)))
     return name in self._node_name_to_node.keys()

--- a/graph_def_editor/node.py
+++ b/graph_def_editor/node.py
@@ -595,7 +595,7 @@ class Node(object):
     """
     Remove any attributes that are attached to this node.
     """
-    self._attributes.clear()
+    self._attributes = []
 
   def _attr_names(self):
     # type: () -> List[str]
@@ -734,7 +734,7 @@ class Node(object):
     """
     Remove this node from amy collections that it is currently a member of.
     """
-    self._collection_names.clear()
+    self._collection_names = set()
 
 
 ################################################################################

--- a/graph_def_editor/node.py
+++ b/graph_def_editor/node.py
@@ -19,7 +19,9 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from typing import Tuple, List, Iterable, Any, AbstractSet, Sized
+import sys
+if sys.version >= '3':
+  from typing import Tuple, List, Iterable, Any, AbstractSet
 
 from graph_def_editor import graph, tensor, util
 
@@ -815,7 +817,8 @@ def _decode_control_inputs(inputs, # type: Iterable[str]
   return [g[name] for name in control_input_names]
 
 
-def _validate_colocation_group_attr(value: Any) -> List[str]:
+def _validate_colocation_group_attr(value):
+  # type: (Any) -> List[str]
   """Validate a potential value for the special "_class" attribute that
   holds collocation groups.
 

--- a/graph_def_editor/rewrite.py
+++ b/graph_def_editor/rewrite.py
@@ -25,7 +25,9 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
-from typing import Tuple, Dict, Iterable, Union, Callable, Any
+import sys
+if sys.version >= '3':
+  from typing import Tuple, Dict, Iterable, Union, Callable, Any
 
 from graph_def_editor import graph, node, reroute, tensor, util
 
@@ -570,7 +572,8 @@ def fold_batch_norms_up(g):
   ```
     ReLU => Min(6 / multiplier from batch norm)
   """
-  def compute_input_dim(n: node.Node):
+  def compute_input_dim(n #type: node.Node
+                        ):
     if n.op_type == "Conv2D" or n.op_type == "DepthwiseConv2dNative":
       return 2
     elif n.op_type == "MatMul":

--- a/graph_def_editor/select.py
+++ b/graph_def_editor/select.py
@@ -24,7 +24,9 @@ import re
 from six import iteritems
 from six import string_types
 import textwrap
-from typing import Any, Dict, List, Iterable, Tuple, Union
+import sys
+if sys.version >= '3':
+  from typing import Dict, List, Iterable, Tuple, Union
 
 from graph_def_editor import util
 from graph_def_editor.graph import Graph
@@ -831,10 +833,10 @@ class TreeExpr(object):
   """
 
   def __init__(self,
-               alias: str = None,
-               op: str = None,
-               optional: bool = None,
-               inputs: Union["TreeExpr", Iterable["TreeExpr"]] = None,
+               alias=None, # type: str
+               op=None, # type: str
+               optional=None, # type: bool
+               inputs=None # type: Union["TreeExpr", Iterable["TreeExpr"]]
                ):
     """
     Args:
@@ -887,7 +889,10 @@ class TreeExpr(object):
   def __str__(self):
     return repr(self)
 
-  def eval_from(self, potential_root_node: Node) -> Dict[str, Node]:
+  def eval_from(self,
+                potential_root_node # type: Node
+                ):
+    # type: (...) -> Dict[str, Node]
     """
     Evaluate a tree expression starting from a potential root node.
 
@@ -914,7 +919,9 @@ class TreeExpr(object):
     else:
       return None
 
-  def _eval_without_optional(self, potential_root_node: Node):
+  def _eval_without_optional(self,
+                             potential_root_node # type: Node
+                             ):
     """
     Handle every part of the expression except the "optional" clause.
     """

--- a/graph_def_editor/select.py
+++ b/graph_def_editor/select.py
@@ -191,7 +191,7 @@ def filter_ops_by_optype(
 
   Returns a list of the `gde.Node`s that have one of the indicated optypes
   """
-  if isinstance(op_types, str):
+  if isinstance(op_types, string_types):
     op_types = [op_types]
   return filter_ops(ops, lambda n: n.op_type in op_types)
 

--- a/graph_def_editor/tensor.py
+++ b/graph_def_editor/tensor.py
@@ -14,7 +14,9 @@
 # ==============================================================================
 
 import tensorflow as tf
-from typing import AbstractSet
+import sys
+if sys.version >= '3':
+  from typing import AbstractSet
 
 __all__ = [
   "Tensor",
@@ -27,7 +29,12 @@ class Tensor(object):
   a tf.Tensor in the TensorFlow Python API, though serialized TensorFlow graphs
   do not contain any separate objects that represent tensors.
   """
-  def __init__(self, node, index, dtype: tf.DType, shape: tf.shape):
+  def __init__(self,
+               node,
+               index,
+               dtype, # type: tf.DType,
+               shape # type: tf.shape
+               ):
     """
     Args:
       node: gde.Node object that represents the graph node that produces this
@@ -69,19 +76,25 @@ class Tensor(object):
     return self._index
 
   @property
-  def dtype(self) -> tf.DType:
+  def dtype(self):
+    # type () -> tf.DType:
     return self._dtype
 
   @dtype.setter
-  def dtype(self, value: tf.DType):
+  def dtype(self,
+            value # type: tf.DType
+            ):
     self._dtype = value
 
   @property
-  def shape(self) -> tf.TensorShape:
+  def shape(self):
+    # type () -> tf.TensorShape
     return self._shape
 
   @shape.setter
-  def shape(self, value: tf.TensorShape):
+  def shape(self,
+            value # type: tf.TensorShape
+            ):
     self._shape = value
 
   @property
@@ -112,14 +125,17 @@ class Tensor(object):
     return "{}:{}".format(self.node.name, self.value_index)
 
   @property
-  def collection_names(self) -> AbstractSet[str]:
+  def collection_names(self):
+    # type -> AbstractSet[str]
     """
     Returns the names of all collections this tensor is a member of in the
     parent graph.
     """
     return frozenset(self._collection_names)
 
-  def add_to_collection(self, collection_name: str):
+  def add_to_collection(self,
+                        collection_name # type: str
+                        ):
     """
     Add the tensor to the indicated collection.
     """

--- a/graph_def_editor/transform.py
+++ b/graph_def_editor/transform.py
@@ -26,7 +26,9 @@ from six import iterkeys
 from six import string_types
 from six import StringIO
 import tensorflow as tf
-from typing import Iterable
+import sys
+if sys.version >= '3':
+  from typing import Iterable
 
 from graph_def_editor import select, subgraph, util
 from graph_def_editor.node import Node
@@ -136,9 +138,12 @@ def transform_op_if_inside_handler(info, op, keep_if_possible=True):
       return None
 
 
-def copy_op_handler(info, op: Node, new_inputs: Iterable[Tensor],
-                    copy_shape_and_dtype: bool = False,
-                    nodedef_fn=None):
+def copy_op_handler(info,
+                    op, # type: node.Node
+                    new_inputs, # type: Iterable[Tensor]
+                    copy_shape_and_dtype=False, # type: bool
+                    nodedef_fn=None
+                    ):
   """Copy a node into the target graph.
 
   Args:
@@ -327,7 +332,11 @@ class _TmpInfo(object):
   argument to the handlers.
   """
 
-  def __init__(self, sgv, dst_graph: Graph, dst_scope, src_scope):
+  def __init__(self,
+               sgv,
+               dst_graph, #type: Graph
+               dst_scope,
+               src_scope):
     self.sgv = sgv
     self.sgv_inputs_set = frozenset(sgv.inputs)
     self.ops = frozenset(sgv.ops)

--- a/graph_def_editor/util.py
+++ b/graph_def_editor/util.py
@@ -22,7 +22,9 @@ from __future__ import print_function
 
 import collections
 import re
-from typing import Any, List
+import sys
+if sys.version >= '3':
+  from typing import Any, List
 
 import numpy as np
 from six import iteritems
@@ -263,8 +265,8 @@ def make_list_of_op(ops, check_graph=True, allow_graph=True, ignore_ts=False):
     return [op for op in ops if isinstance(op, node.Node)]
 
 
-def make_list_of_t(ts, check_graph=True, allow_graph=True, ignore_ops=False) \
-  -> List[tensor.Tensor]:
+def make_list_of_t(ts, check_graph=True, allow_graph=True, ignore_ops=False):
+  # type: (...) -> List[tensor.Tensor]
   """Convert ts to a list of `gde.Tensor`.
 
   Args:
@@ -332,7 +334,9 @@ def get_consuming_ops(ts):
 class ControlOutputs(object):
   """The control outputs topology."""
 
-  def __init__(self, g: 'graph.Graph'):
+  def __init__(self,
+               g # type: graph.Graph
+               ):
     """Create a dictionary of control-output dependencies.
 
     Args:
@@ -441,8 +445,12 @@ def placeholder_name(t=None, scope=None, prefix=_DEFAULT_PLACEHOLDER_PREFIX):
     return "{}{}".format(scope, prefix)
 
 
-def make_placeholder_from_tensor(g: 'graph.Graph', t: tensor.Tensor, scope=None,
-                                 prefix=_DEFAULT_PLACEHOLDER_PREFIX):
+def make_placeholder_from_tensor(
+        g, # type: graph.Graph
+        t, # type: tensor.Tensor
+        scope=None,
+        prefix=_DEFAULT_PLACEHOLDER_PREFIX
+        ):
   """Create a `gde.Node` representing a `tf.placeholder` for the Graph Editor.
 
   Note that the correct graph scope must be set by the calling function.
@@ -558,8 +566,10 @@ def find_corresponding(targets, dst_graph, dst_scope="", src_scope=""):
   return transform_tree(targets, func)
 
 
-def _python_type_to_attr_list_elem(list_value: tf.AttrValue.ListValue,
-                                   elem: Any):
+def _python_type_to_attr_list_elem(
+        list_value, # type: tf.AttrValue.ListValue
+        elem # type: Any
+  ):
   """
   Subroutine of python_type_to_attr_value(). Converts one element of a Python
   list to one element of a `tf.AttrValue.ListValue` protobuf.
@@ -590,7 +600,9 @@ def _python_type_to_attr_list_elem(list_value: tf.AttrValue.ListValue,
                      "tf.AttrValue.ListValue".format(type(elem)))
 
 
-def python_type_to_attr_value(value: Any) -> tf.AttrValue:
+def python_type_to_attr_value(value #type: Any
+                              ):
+  # type (...) -> tf.AttrValue
   """
   Convert a Python object or scalar value to a TensorFlow `tf.AttrValue`
   protocol buffer message.
@@ -638,7 +650,9 @@ def python_type_to_attr_value(value: Any) -> tf.AttrValue:
                      "tf.AttrValue".format(type(value)))
 
 
-def attr_value_to_python_type(attr_value: tf.AttrValue) -> Any:
+def attr_value_to_python_type(attr_value # type: tf.AttrValue
+                              ):
+  # type (...) -> Any
   """
   Inverse of python_type_to_attr_value().
 
@@ -674,7 +688,8 @@ def attr_value_to_python_type(attr_value: tf.AttrValue) -> Any:
                      "a Python object".format(attr_value))
 
 
-def load_variables_to_tf_graph(g: 'graph.Graph'):
+def load_variables_to_tf_graph(g # type: graph.Graph
+                               ):
   """
   Convenience function to load all variables present in a `gde.Graph` into
   the current default TensorFlow graph, without generating a MetaGraphDef.
@@ -690,8 +705,11 @@ def load_variables_to_tf_graph(g: 'graph.Graph'):
     tf.add_to_collections(var.collection_names, tf_var)
 
 
-def make_const(g: 'graph.Graph', name: str, value: np.ndarray,
-               uniquify_name: bool = False):
+def make_const(g, # type: graph.Graph
+               name, # type: str
+               value, # type: np.ndarray
+               uniquify_name=False # type: bool
+               ):
   """
   Convenience method to add a `Const` op to a `gde.Graph`.
 
@@ -713,9 +731,12 @@ def make_const(g: 'graph.Graph', name: str, value: np.ndarray,
   return ret
 
 
-def make_placeholder(g: 'graph.Graph', name: str, dtype: tf.DType,
-                     shape: tf.TensorShape,
-                     uniquify_name: bool = False):
+def make_placeholder(g, # type: graph.Graph
+                     name, # type: str
+                     dtype, # type: tf.DType
+                     shape, #type: tf.TensorShape
+                     uniquify_name=False # type: bool
+                     ):
   """
   Convenience method to add a `Placeholder` op to a `gde.Graph`.
 
@@ -736,8 +757,11 @@ def make_placeholder(g: 'graph.Graph', name: str, dtype: tf.DType,
   return ret
 
 
-def make_identity(g: 'graph.Graph', name: str, input: 'tensor.Tensor',
-                  uniquify_name: bool = False):
+def make_identity(g, # type: graph.Graph
+                  name, # type: str
+                  input, # type: tensor.Tensor
+                  uniquify_name=False # type: bool
+                  ):
   """
   Convenience method to add an `Identity` op to a `gde.Graph`.
 
@@ -758,9 +782,14 @@ def make_identity(g: 'graph.Graph', name: str, input: 'tensor.Tensor',
   return ret
 
 
-def make_simple_binary_op(g: 'graph.Graph', name: str, op_name: str,
-                          input_1: tensor.Tensor, input_2: tensor.Tensor,
-                          dtype = None, uniquify_name: bool = False):
+def make_simple_binary_op(g, # type: graph.Graph
+                          name, # type: str
+                          op_name, # type: str
+                          input_1, # type: tensor.Tensor
+                          input_2, # type: tensor.Tensor
+                          dtype=None, # type: tf.DType
+                          uniquify_name=False # type: bool
+                          ):
   """
   Convenience method to cover the common case of binary ops. To be used with
   this pattern, ops must satisfy the following:

--- a/graph_def_editor/util.py
+++ b/graph_def_editor/util.py
@@ -27,7 +27,7 @@ if sys.version >= '3':
   from typing import Any, List
 
 import numpy as np
-from six import iteritems
+from six import iteritems, string_types
 import tensorflow as tf
 
 from graph_def_editor import graph, node, tensor
@@ -579,7 +579,7 @@ def _python_type_to_attr_list_elem(
       proto. Modified in place.
     elem: Original value to convert.
   """
-  if isinstance(elem, str):
+  if isinstance(elem, string_types):
     list_value.s.append(tf.compat.as_bytes(elem))
   # Must check for bool before int because bool is a subclass of int in Python
   elif isinstance(elem, bool):
@@ -628,7 +628,7 @@ def python_type_to_attr_value(value #type: Any
     # TODO(frreiss): Should this case result in an error?
     return value
   # Scalar types, in the order they appear in the .proto file
-  elif isinstance(value, str):
+  elif isinstance(value, string_types):
     return tf.AttrValue(s=tf.compat.as_bytes(value))
   # Must check for bool before int because bool is a subclass of int in Python
   elif isinstance(value, bool):

--- a/graph_def_editor/variable.py
+++ b/graph_def_editor/variable.py
@@ -19,14 +19,13 @@ from tensorflow.core.framework import variable_pb2
 
 import sys
 if sys.version >= '3':
+  from graph_def_editor import graph
   from typing import AbstractSet, Union
 
 
 __all__ = [
   "Variable",
 ]
-
-from graph_def_editor import graph
 
 
 class Variable(object):

--- a/graph_def_editor/variable.py
+++ b/graph_def_editor/variable.py
@@ -17,7 +17,9 @@
 #  tf.core.framework
 from tensorflow.core.framework import variable_pb2
 
-from typing import AbstractSet, Union
+import sys
+if sys.version >= '3':
+  from typing import AbstractSet, Union
 
 
 __all__ = [
@@ -41,7 +43,9 @@ class Variable(object):
   TensorFlow's Python API has a class `tf.Variable` that tracks these
   objects. This class tracks a similar set of pointers in protobuf land.
   """
-  def __init__(self, g: 'graph.Graph'):
+  def __init__(self,
+               g # type: graph.Graph
+               ):
     """
     Do not call this constructor directly.
 
@@ -75,7 +79,9 @@ class Variable(object):
                                    self._snapshot_name,
                                    self._trainable)
 
-  def is_same_variable(self, other: 'Variable'):
+  def is_same_variable(self,
+                       other # type: Variable
+                       ):
     """
     Returns true if is variable and `other` are the same, ignoring graph and
     collection information.
@@ -93,8 +99,11 @@ class Variable(object):
     else:
       return True
 
-  def from_proto(self, variable_def: Union[variable_pb2.VariableDef, bytes],
-                 validate: bool = True, allow_duplicates: bool = False):
+  def from_proto(self,
+                 variable_def, # type: Union[variable_pb2.VariableDef, bytes]
+                 validate=True, # type: bool
+                 allow_duplicates=False # type: bool
+                 ):
     """
     Populate the fields of this object from a serialized TensorFlow variable.
 
@@ -142,7 +151,9 @@ class Variable(object):
     ret.trainable = self._trainable
     return ret
 
-  def validate(self, allow_duplicate: bool = False):
+  def validate(self,
+               allow_duplicate=False # type: bool
+               ):
     """
     Verify that all the names this variable references are valid in the
     parent graph and that no conflicting variables exist.
@@ -171,7 +182,8 @@ class Variable(object):
     _ = self.graph.get_tensor_by_name(self._snapshot_name,
                                       "Invalid snapshot name '{}': {}")
 
-  def to_proto(self) -> variable_pb2.VariableDef:
+  def to_proto(self):
+    # type: () -> variable_pb2.VariableDef
     """
     Convert this object into its equivalent TensorFlow protocol buffer
     message.
@@ -198,7 +210,9 @@ class Variable(object):
     return self._variable_name
 
   @name.setter
-  def name(self, val: str):
+  def name(self,
+           val # type: str
+           ):
     # TODO(frreiss): Should we update the graph here?
     self._variable_name = val
 
@@ -219,14 +233,17 @@ class Variable(object):
     return self._trainable
 
   @property
-  def collection_names(self) -> AbstractSet[str]:
+  def collection_names(self):
+    # type: () -> AbstractSet[str]
     """
     Returns the names of all collections this variable is a member of in the
     parent graph.
     """
     return frozenset(self._collection_names)
 
-  def add_to_collection(self, collection_name: str):
+  def add_to_collection(self,
+                        collection_name # type: str
+                        ):
     """
     Add the variable to the indicated collection.
     """

--- a/tests/rewrite_test.py
+++ b/tests/rewrite_test.py
@@ -28,7 +28,11 @@ import graph_def_editor as gde
 
 class RewriteTest(unittest.TestCase):
 
-  def assertClose(self, expected: np.ndarray, actual: np.ndarray, delta: float):
+  def assertClose(self,
+                  expected, # type: np.ndarray
+                  actual, # type: np.ndarray
+                  delta, # type: float
+                  ):
     """
     Assert that all values in two arrays are within a certain distance of
     each other.
@@ -385,7 +389,8 @@ class RewriteTest(unittest.TestCase):
     Version of test_fold_fused_batch_norms() with a depthwise convolution op
     """
     # We try this test with channel multipliers of 1 and 2
-    def run_test(channel_multiplier_is_one: bool):
+    def run_test(channel_multiplier_is_one # type: bool
+                 ):
       input_data = (
         np.array([1., 4., 2., 5., 3., 6., -1., -4., -2., -5., -3., -6.],
                  dtype=np.float32).reshape([1, 1, 6, 2])
@@ -456,7 +461,8 @@ class RewriteTest(unittest.TestCase):
     """
     # Run the test twice, changing how we concatenate the outputs of our two
     # convolutions.
-    def run_test(split: bool):
+    def run_test(split # type: bool
+                 ):
       """
       Args:
         split: if True, concatenate along channels dimension


### PR DESCRIPTION
This fixes more compatibility issues with Python 2.7 including:

* Remaining references to typing specifiers
* Make typing module imports conditional to Python 3
* Use six.string_types when checking for instances of strings
* Change usage of `clear()` for lists/sets