### PR TITLE
Implement missing add-to-collection code (fixes #36)

### DIFF
--- a/graph_def_editor/graph.py
+++ b/graph_def_editor/graph.py
@@ -240,6 +240,10 @@ class Graph(object):
     Unpack a `tf.MetaGraphDef.CollectionDefEntry` of serialized variables 
     into a collection of variables in this graph. The collection must not exist. 
     Variables that do not already exist will be created.
+
+    Note that this method is intended to be used to bulk-load a collection.
+    To add individual items to a collection one-by-one, call the
+    `add_to_collection` methods of `Node`, etc., objects.
     
     Args:
       collection_name: Name of collection
@@ -271,7 +275,8 @@ class Graph(object):
       if self._collection_name_to_type is not None:
         self._collection_name_to_type[collection_name] = "passthrough"
     else:
-      raise ValueError("Unknown collection with name: {}".format(collection_name))
+      raise ValueError("Unknown collection with name: {}".format(
+        collection_name))
 
   def __getitem__(self, name):
     # type: (str) -> Union[tensor.Tensor, 'node.Node']

--- a/graph_def_editor/transform.py
+++ b/graph_def_editor/transform.py
@@ -119,9 +119,12 @@ def assign_renamed_collections_handler(info, elem, elem_):
     if isinstance(elem_, (Node, Tensor, Variable)):
       elem_.add_to_collection(transformed_name)
     else:
-      raise NotImplementedError("Don't know how to add name '{}' to target "
+      raise NotImplementedError("Unable to add name '{}' to target "
                                 "graph as a collection item (target collection "
-                                "name {})".format(elem_, transformed_name))
+                                "name {}) because the object doesn't "
+                                "have an implementation of "
+                                "add_to_collection()"
+                                "".format(elem_, transformed_name))
 
 
 def transform_op_if_inside_handler(info, op, keep_if_possible=True):

--- a/tests/transform_test.py
+++ b/tests/transform_test.py
@@ -176,7 +176,7 @@ class TransformTest(unittest.TestCase):
     #   _ = tf.constant(10.0, shape=[10], name="Input")
     # New code adds node as a NodeDef
     ten_node = gde.make_const(self.graph, "Ten", np.full([10], 10.,
-                                                                      dtype=np.float32))
+                              dtype=np.float32))
 
     ten_tensor = ten_node.output(0)
     sgv, _ = gde.copy_with_input_replacements(
@@ -195,6 +195,20 @@ class TransformTest(unittest.TestCase):
     print("val is {}".format(val))
     self.assertNear(
       np.linalg.norm(val - np.array([11])), 0.0, ERROR_TOLERANCE)
+
+
+  def test_copy_with_collection(self):
+    """Test for issue #36"""
+    tmp_graph = tf.Graph()
+    with tmp_graph.as_default():
+      c = tf.constant(42, name="FortyTwo")
+      tmp_graph.add_to_collection("Answers", c)
+
+    g = gde.Graph(tmp_graph)
+    g2 = gde.Graph()
+    gde.transform.copy(g, g2)
+    self.assertTrue("Answers" in g2.get_all_collection_keys())
+
 
   @staticmethod
   def _create_replace_graph():


### PR DESCRIPTION
This PR contains a fix for issue #36 . Specific changes:
* Reimplemented `transform.assign_renamed_collections_handler()` using GDE APIs.
* Added a test case that reproduced the original issue
* Updated the API comment for `Graph.add_collection_from_collection_def()` with a reminder that `add_to_collection` is a method of the `Node`, `Tensor`, etc. objects in GDE, as opposed to a method of the graph.