### PR TITLE
Undefined name: Add missing "value" parameter to a setter

### DIFF
--- a/graph_def_editor/node.py
+++ b/graph_def_editor/node.py
@@ -345,7 +345,7 @@ class Node(object):
     return tuple(self._colocation_groups)
 
   @colocation_groups.setter
-  def colocation_groups(self):
+  def colocation_groups(self, value):
     # type: (Iterable[str]) -> None
     """
     Setter for the `colocation_groups` property.


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/codait/graph_def_editor on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./graph_def_editor/node.py:358:14: F821 undefined name 'value'
    for s in value:
             ^
./graph_def_editor/node.py:362:31: F821 undefined name 'value'
    self._colocation_groups = value
                              ^
2    F821 undefined name 'value'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree