### PR TITLE
Adding tensor.py to __init__ file

### DIFF
--- a/graph_def_editor/__init__.py
+++ b/graph_def_editor/__init__.py
@@ -30,6 +30,7 @@ from graph_def_editor.node import *
 from graph_def_editor.reroute import *
 from graph_def_editor.select import *
 from graph_def_editor.subgraph import *
+from graph_def_editor.tensor import *
 from graph_def_editor.transform import *
 from graph_def_editor.util import *
 from graph_def_editor.variable import *


### PR DESCRIPTION
Added a line to import the tensor module within the init file, it was the only one missing and this way gde.Tensor() can be called instead of writing out gde.tensor.Tensor().